### PR TITLE
Add configurable defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Twitch Chat Viewer
+
+This project streams messages from a Twitch channel and displays them in a web interface.
+
+## Configuration
+
+Default configuration values reside in `config.js`:
+
+- `port` – the HTTP server port (defaults to `3000`)
+- `channel` – the Twitch channel to connect to (defaults to `illojuan`)
+
+At runtime you can override these by setting the environment variables `PORT` and
+`TWITCH_CHANNEL`.
+
+Example:
+
+```bash
+PORT=4000 TWITCH_CHANNEL=mychannel npm start
+```
+
+If no environment variables are provided the values from `config.js` will be used.
+Adjust `config.js` if you want to change the defaults in version control.

--- a/app.js
+++ b/app.js
@@ -3,7 +3,8 @@ const app = express();
 const http = require('http').Server(app);
 const io = require('socket.io')(http);
 const tmi = require('tmi.js');
-const port = process.env.PORT || 3000;
+const config = require('./config');
+const port = process.env.PORT || config.port;
 
 app.use(express.static(__dirname + '/app'));
 
@@ -27,7 +28,7 @@ http.listen(port, () => {
     console.log('Servidor encendido en el puerto' , `${port}`);
 });
 
-const defaultChannel = process.env.TWITCH_CHANNEL || 'illojuan';
+const defaultChannel = process.env.TWITCH_CHANNEL || config.channel;
 let client = new tmi.Client({
     channels: [defaultChannel],
     connection: { reconnect: false }

--- a/config.js
+++ b/config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  port: 3000,
+  channel: 'illojuan'
+};


### PR DESCRIPTION
## Summary
- create configuration module for default port and channel
- read configuration in `app.js`
- document how to update configuration

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a97cfcffc8324bb0bc0b8f661c6c0