### PR TITLE
Improve logging and add runtime metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ PORT=4000 TWITCH_CHANNEL=mychannel npm start
 
 If no environment variables are provided the values from `config.js` will be used.
 Adjust `config.js` if you want to change the defaults in version control.
+
+## Metrics
+
+The server exposes basic runtime metrics at `http://localhost:<port>/metrics`.
+These metrics include the number of connections, disconnections and detected
+misuse events.


### PR DESCRIPTION
## Summary
- add a simple metrics tracker and helper logger
- log socket id on connect/disconnect and when joining a channel
- record potential misuse with a new `bug` event
- expose `/metrics` endpoint
- document metrics endpoint in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a9d6f78248324be09f7482340d290