### PR TITLE
Enhance front‑end look

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -13,23 +13,23 @@
 </head>
 <body>
     <div class="container-fluid">
-        <div class="row p-2" id="header">
+        <div class="row align-items-center p-3" id="header">
             <div class="col">
                 <h4 id="titulo">Twitch chat</h4>
             </div>
-            <div class="col mt-2">
-                <input class="form-control form-control-sm" placeholder="Introduce el nombre del canal" id="nombre">
+            <div class="col mt-2 mt-md-0">
+                <input placeholder="Introduce el nombre del canal" id="nombre">
             </div>
-            <div class="col mt-2">
-                <button class="btn btn-sm" id="cambiar">Cambiar</button>
-                <button class="btn btn-sm" id="bug">Reiniciar</button>
+            <div class="col-auto mt-2 mt-md-0">
+                <button id="cambiar">Cambiar</button>
+                <button id="bug">Reiniciar</button>
             </div>
             <div class="row">
                 <p>Contador de mensaje:<span id="contador"></span></p>
             </div>
         </div>
         <div class="row justify-content-center">
-            <div class="overflow-auto align-self-center p-3 my-5 col-12 rounded shadow" id="chat"></div>
+            <div class="align-self-center p-3 my-5 col-12" id="chat"></div>
         </div>
     </div>
     <script src="/socket.io/socket.io.js"></script>

--- a/app/responsive.css
+++ b/app/responsive.css
@@ -1,61 +1,16 @@
 #chat {
-    height: 1100px;
-    width: 1500px;
-    overflow-x: scroll;
-    overflow-y: hidden;
-    transition: all 1s cubic-bezier(0.1, 0.79, 0.49, 0.96) 0s
+  transition: all 0.4s ease;
+  width: 100%;
 }
 
-@media screen and (max-height: 1300px) {
-    #chat {
-        height: 1060px;
-        
-    }
-}
-@media screen and (max-height: 1200px) {
-    #chat {
-        height: 960px;
-    }
+@media (min-width: 768px) {
+  #chat {
+    height: 75vh;
+  }
 }
 
-@media screen and (max-height: 1100px) {
-    #chat {
-        height: 860px;
-    }
-}
-
-@media screen and (max-height: 1000px) {
-    #chat {
-        height: 760px;
-    }
-}
-
-@media screen and (max-height: 900px) {
-    #chat {
-        height: 660px;
-    }
-}
-
-@media screen and (max-height: 800px) {
-    #chat {
-        height: 560px;
-    }
-}
-
-@media screen and (max-height: 700px) {
-    #chat {
-        height: 460px;
-    }
-}
-
-@media screen and (max-height: 600px) {
-    #chat {
-        height: 360px;
-    }
-}
-
-@media screen and (max-height: 500px) {
-    #chat {
-        height: 260px;
-    }
+@media (min-width: 1200px) {
+  #chat {
+    height: 80vh;
+  }
 }

--- a/app/style.css
+++ b/app/style.css
@@ -1,76 +1,90 @@
-body {
-    scroll-behavior: smooth;
-    background-color: #343a40;
-    color: white;
-}
-
-b {
-    color: var(--bg);
-}
-
 :root {
-    --bg: #a970ff;
-    --grey: #1f1f23;
+  --accent: #0a84ff;
+  --panel-bg: #ffffff;
+  --page-bg: #f5f5f7;
+  --text-color: #1c1c1e;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
+  background: var(--page-bg);
+  color: var(--text-color);
+  scroll-behavior: smooth;
 }
 
 #header {
-    background-color: var(--grey);
-    color: var(--bg);
-    border-bottom: 1px solid var(--bg);
+  background: var(--panel-bg);
+  color: var(--text-color);
+  border-bottom: 1px solid rgba(0,0,0,0.1);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
 }
 
 #chat {
-    background-color: var(--grey);
-    border-bottom: 1px solid var(--bg);
+  background: var(--panel-bg);
+  border: 1px solid rgba(0,0,0,0.1);
+  border-radius: 12px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.05);
+  height: 70vh;
+  max-width: 900px;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
-#cambiar, #nombre, #bug {
-    background-color: var(--grey) !important;
-    border: 1px solid var(--bg);
-    color: var(--bg);
-    transition: 0.5s;
-}
-
-#nombre:focus {
-    box-shadow: var(--bg) 0 0 0 0.05rem ;
+#cambiar, #bug {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 0.25rem 1rem;
+  border-radius: 6px;
+  transition: background 0.3s ease;
 }
 
 #cambiar:hover, #bug:hover {
-    background-color: var(--bg) !important;
-    color: var(--grey);
+  background: #006fe6;
+}
+
+#nombre {
+  border: 1px solid #ccc;
+  border-radius: 6px;
+}
+
+#nombre:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(10,132,255,0.3);
+  border-color: var(--accent);
 }
 
 #mensaje {
-    border-bottom: 1px solid var(--bg) !important;
+  border-bottom: 1px solid rgba(0,0,0,0.1);
+  padding: 0.25rem 0;
 }
 
 #contador {
-    color: white;
+  font-weight: 500;
 }
 
+b {
+  color: var(--accent);
+}
 
 #chat::-webkit-scrollbar {
-    width: 5px;
+  width: 6px;
 }
 
 #chat::-webkit-scrollbar-track {
-    background: rgb(46, 46, 46);
+  background: transparent;
 }
 
 #chat::-webkit-scrollbar-thumb {
-    background: var(--bg);
-}
-
-#chat::-webkit-scrollbar-thumb:hover {
-    background: #442d66;
-    transition: 0.5;   
+  background: rgba(0,0,0,0.2);
+  border-radius: 3px;
 }
 
 .aviso {
-    border-top: 1px var(--bg) !important;
-    border-bottom: 1px var(--bg) !important;
+  border-top: 1px solid var(--accent) !important;
+  border-bottom: 1px solid var(--accent) !important;
 }
 
 .bg-color {
-    background-color: var(--bg) !important;
+  background-color: var(--accent) !important;
 }


### PR DESCRIPTION
## Summary
- redesign style.css with minimal look using Apple-like colors
- simplify responsive chat layout
- remove Bootstrap styling from the form and buttons

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a9f8362d48324850f7488491d1803