### PR TITLE
Handle Twitch reconnect events

### DIFF
--- a/app.js
+++ b/app.js
@@ -50,7 +50,7 @@ io.on('connection', (socket) => {
         if (!channels[channelName]) {
             const client = new tmi.Client({
                 channels: [channelName],
-                connection: { reconnect: false }
+                connection: { reconnect: true }
             });
             channels[channelName] = { client, sockets: new Set(), messages: [] };
 
@@ -67,6 +67,18 @@ io.on('connection', (socket) => {
                     }
                 }
                 io.to(channelName).emit('mensaje', mensaje);
+            });
+
+            client.on('connected', () => {
+                io.to(channelName).emit('twitch-status', 'connected');
+            });
+
+            client.on('disconnected', () => {
+                io.to(channelName).emit('twitch-status', 'disconnected');
+            });
+
+            client.on('reconnect', () => {
+                io.to(channelName).emit('twitch-status', 'reconnect');
             });
 
             try {

--- a/app/index.html
+++ b/app/index.html
@@ -28,6 +28,7 @@
             <div class="row">
                 <p>Contador de mensaje:<span id="contador"></span></p>
                 <p id="watchers" class="mt-1"></p>
+                <p id="status" class="mt-1"></p>
             </div>
         </div>
         <div class="row justify-content-center">

--- a/app/index.js
+++ b/app/index.js
@@ -4,6 +4,7 @@ let cont = 0;
 let parar = false;
 let currentChannel = defaultChannel;
 const watchersEl = document.getElementById('watchers');
+const statusEl = document.getElementById('status');
 
 // Join default channel once connected
 socket.emit('join', defaultChannel);
@@ -52,6 +53,16 @@ socket.on('watchers', (count) => {
         watchersEl.textContent = `Somos ${count} viendo este chat`;
     } else {
         watchersEl.textContent = '';
+    }
+});
+
+socket.on('twitch-status', (state) => {
+    if (state === 'connected') {
+        statusEl.textContent = 'Conectado a Twitch';
+    } else if (state === 'disconnected') {
+        statusEl.textContent = 'Desconectado de Twitch';
+    } else if (state === 'reconnect') {
+        statusEl.textContent = 'Reconectando a Twitch...';
     }
 });
 


### PR DESCRIPTION
## Summary
- enable automatic reconnects when connecting to Twitch
- emit `twitch-status` events for connected, disconnected and reconnect states
- show status messages in the client

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c0136589c83248628f954ce315814