### PR TITLE
Show watchers in header

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -25,10 +25,8 @@
                 <button class="btn btn-sm" id="bug">Reiniciar</button>
                 <button class="btn btn-sm" id="descargar">Descargar JSON</button>
             </div>
-            <div class="row">
-                <p>Contador de mensaje:<span id="contador"></span></p>
-                <p id="watchers" class="mt-1"></p>
-            </div>
+            <p id="watchers" class="col-auto mt-2 mb-0"></p>
+            <p class="col mt-2 mb-0">Contador de mensaje:<span id="contador"></span></p>
         </div>
         <div class="row justify-content-center">
             <div class="overflow-auto align-self-center p-3 my-5 col-12 rounded shadow" id="chat"></div>

--- a/app/index.js
+++ b/app/index.js
@@ -48,11 +48,7 @@ socket.on('mensaje', (mensaje) => {
 })
 
 socket.on('watchers', (count) => {
-    if (count > 1) {
-        watchersEl.textContent = `Somos ${count} viendo este chat`;
-    } else {
-        watchersEl.textContent = '';
-    }
+    watchersEl.textContent = `👁️ ${count}`;
 });
 
 document.getElementById('cambiar').onclick = function() {

--- a/app/style.css
+++ b/app/style.css
@@ -65,6 +65,10 @@ body {
   font-weight: 500;
 }
 
+#watchers {
+  font-weight: 500;
+}
+
 b {
   color: var(--accent);
 }


### PR DESCRIPTION
## Summary
- move watchers element next to the channel controls
- always show eye icon with number of viewers
- add simple style for watchers element

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c01390b9c8324bd33dae610f6eab9