### PR TITLE
Add private sidebar chat rooms

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,12 +21,15 @@ function logEvent(message) {
 app.use(express.static(__dirname + '/app'));
 
 // Map to keep track of tmi clients, sockets and stored messages per channel
+// In addition to Twitch messages we also keep a private chat log per channel.
 const channels = {};
 
 function sendWatchers(channelName) {
     const channel = channels[channelName];
     if (!channel) return;
     io.to(channelName).emit('watchers', channel.sockets.size);
+    const list = Array.from(channel.sockets).map((s) => s.username || s.id);
+    io.to(channelName).emit('watcher-list', list);
 }
 
 io.on('connection', (socket) => {
@@ -34,10 +37,14 @@ io.on('connection', (socket) => {
     metrics.activeSockets++;
     logEvent(`Conectado ${socket.id} desde ${socket.handshake.address}. Activas: ${metrics.activeSockets}`);
 
-    socket.on('join', async (channelName) => {
+    socket.on('join', async (data) => {
+        const channelName = typeof data === 'string' ? data : data.channel;
+        const username = typeof data === 'string' ? socket.username || socket.id : data.user || socket.id;
         if (!channelName) {
             return;
         }
+
+        socket.username = username;
 
         // Leave previous channel if switching
         if (socket.channelName && socket.channelName !== channelName) {
@@ -52,7 +59,7 @@ io.on('connection', (socket) => {
                 channels: [channelName],
                 connection: { reconnect: true }
             });
-            channels[channelName] = { client, sockets: new Set(), messages: [] };
+            channels[channelName] = { client, sockets: new Set(), messages: [], privateMessages: [] };
 
             client.on('message', (channel, tags, message, self) => {
                 const mensaje = {
@@ -91,7 +98,22 @@ io.on('connection', (socket) => {
 
         channels[channelName].sockets.add(socket);
         socket.join(channelName);
+        // Send existing private chat history to the newly joined socket
+        channels[channelName].privateMessages.forEach((m) => {
+            socket.emit('private-message', m);
+        });
         sendWatchers(channelName);
+    });
+
+    socket.on('private-message', (msg) => {
+        const channelName = socket.channelName;
+        if (!channelName) return;
+        const channel = channels[channelName];
+        if (!channel) return;
+        const data = { user: socket.username, message: msg };
+        channel.privateMessages.push(data);
+        if (channel.privateMessages.length > 100) channel.privateMessages.shift();
+        io.to(channelName).emit('private-message', data);
     });
 
     socket.on('bug', () => {

--- a/app/index.html
+++ b/app/index.html
@@ -21,15 +21,29 @@
                 <input class="form-control form-control-sm" placeholder="Introduce el nombre del canal" id="nombre">
             </div>
             <div class="col mt-2">
+                <input class="form-control form-control-sm" placeholder="Tu nombre" id="username">
+            </div>
+            <div class="col mt-2">
                 <button class="btn btn-sm" id="cambiar">Cambiar</button>
                 <button class="btn btn-sm" id="bug">Reiniciar</button>
                 <button class="btn btn-sm" id="descargar">Descargar JSON</button>
+                <button class="btn btn-sm" id="open-sidebar">Sala</button>
             </div>
             <p id="watchers" class="col-auto mt-2 mb-0"></p>
             <p class="col mt-2 mb-0">Contador de mensaje:<span id="contador"></span></p>
         </div>
         <div class="row justify-content-center">
             <div class="overflow-auto align-self-center p-3 my-5 col-12 rounded shadow" id="chat"></div>
+        </div>
+    </div>
+    <div id="sidebar" class="sidebar">
+        <h6>Personas en la sala</h6>
+        <div id="watcher-list" class="mb-2"></div>
+        <h6>Chat privado</h6>
+        <div id="private-chat" class="mb-2"></div>
+        <div class="input-group input-group-sm">
+            <input id="private-input" class="form-control" placeholder="Mensaje...">
+            <button id="private-send" class="btn btn-primary">Enviar</button>
         </div>
     </div>
     <script src="/socket.io/socket.io.js"></script>

--- a/app/index.js
+++ b/app/index.js
@@ -6,10 +6,28 @@ let currentChannel = defaultChannel;
 const watchersEl = document.getElementById('watchers');
 const statusEl = document.getElementById('status');
 const downloadBtn = document.getElementById('descargar');
+const usernameInput = document.getElementById('username');
+const openSidebarBtn = document.getElementById('open-sidebar');
+const sidebar = document.getElementById('sidebar');
+const watcherListEl = document.getElementById('watcher-list');
+const privateChat = document.getElementById('private-chat');
+const privateInput = document.getElementById('private-input');
+const privateSend = document.getElementById('private-send');
+
 downloadBtn.disabled = true;
 
+function getUsername() {
+    let name = usernameInput.value.trim();
+    if (!name) {
+        name = 'user' + Math.floor(Math.random() * 10000);
+        usernameInput.value = name;
+    }
+    return name;
+}
+
 // Join default channel once connected
-socket.emit('join', defaultChannel);
+const username = getUsername();
+socket.emit('join', { channel: defaultChannel, user: username });
 document.getElementById('nombre').value = defaultChannel;
 
 socket.on('mensaje', (mensaje) => {
@@ -54,10 +72,37 @@ socket.on('watchers', (count) => {
     watchersEl.textContent = `👁️ ${count}`;
 });
 
+socket.on('watcher-list', (list) => {
+    watcherListEl.innerHTML = '';
+    list.forEach((name) => {
+        const div = document.createElement('div');
+        div.textContent = name;
+        watcherListEl.appendChild(div);
+    });
+});
+
+socket.on('private-message', (data) => {
+    const div = document.createElement('div');
+    div.innerHTML = `<b>${data.user}:</b> ${data.message}`;
+    privateChat.appendChild(div);
+    privateChat.scrollTop = privateChat.scrollHeight;
+});
+
+openSidebarBtn.onclick = function() {
+    sidebar.classList.toggle('open');
+};
+
+privateSend.onclick = function() {
+    const msg = privateInput.value.trim();
+    if (!msg) return;
+    socket.emit('private-message', msg);
+    privateInput.value = '';
+};
+
 document.getElementById('cambiar').onclick = function() {
     let nombre = document.getElementById('nombre').value;
     if (nombre.length > 0) {
-        socket.emit('join', nombre);
+        socket.emit('join', { channel: nombre, user: getUsername() });
         currentChannel = nombre;
         const chat = document.getElementById('chat');
         const wrapper = document.createElement('div');

--- a/app/style.css
+++ b/app/style.css
@@ -94,3 +94,34 @@ b {
 .bg-color {
   background-color: var(--accent) !important;
 }
+
+#sidebar {
+  position: fixed;
+  top: 0;
+  right: -280px;
+  width: 280px;
+  height: 100%;
+  background: var(--panel-bg);
+  color: var(--text-color);
+  border-left: 1px solid rgba(0,0,0,0.1);
+  padding: 1rem;
+  overflow-y: auto;
+  transition: right 0.3s ease;
+  z-index: 1040;
+}
+
+#sidebar.open {
+  right: 0;
+}
+
+#open-sidebar {
+  background: var(--accent);
+  color: #fff;
+}
+
+#private-chat {
+  max-height: 40vh;
+  overflow-y: auto;
+  border: 1px solid rgba(0,0,0,0.1);
+  padding: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- support sidebar with chat watchers
- implement per-room private chat
- send watcher list from server
- style sidebar and form inputs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687950dc67948324830e997ea72af809